### PR TITLE
Migrate ASM library to v4 (4.0.31)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,12 +4,12 @@
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="Asm" Version="3.8.162" />
-    <PackageVersion Include="Asm.AspNetCore" Version="3.8.162" />
-    <PackageVersion Include="Asm.AspNetCore.Mvc" Version="3.8.162" />
-    <PackageVersion Include="Asm.Net" Version="3.8.162" />
-    <PackageVersion Include="Asm.Umbraco" Version="3.8.162" />
-    <PackageVersion Include="Asm.Umbraco.Authentication" Version="3.8.162" />
+    <PackageVersion Include="Asm" Version="4.0.31" />
+    <PackageVersion Include="Asm.AspNetCore" Version="4.0.31" />
+    <PackageVersion Include="Asm.AspNetCore.Mvc" Version="4.0.31" />
+    <PackageVersion Include="Asm.Net" Version="4.0.31" />
+    <PackageVersion Include="Asm.Umbraco" Version="4.0.31" />
+    <PackageVersion Include="Asm.Umbraco.Authentication" Version="4.0.31" />
     <PackageVersion Include="Azure.Extensions.AspNetCore.DataProtection.Blobs" Version="1.5.3" />
     <PackageVersion Include="Azure.Extensions.AspNetCore.DataProtection.Keys" Version="1.6.3" />
     <PackageVersion Include="Azure.Identity" Version="1.21.0" />

--- a/src/AmCom.Web/Program.cs
+++ b/src/AmCom.Web/Program.cs
@@ -36,16 +36,24 @@ try
     umbracoBuilder.AddEntraIdAuthentication(builder.Configuration.GetSection("Azure"));
 
     services.AddSecurityReporting(opts => opts.RoutePrefix = "api/reporting");
-    services.AddStandardSecurityHeaders().AddContentSecurityPolicy(options =>
+    services.AddStandardSecurityHeaders(policies =>
     {
-        options.AddDefaultSrc().Self();
-        options.AddConnectSrc().Self();
-        options.AddImgSrc().Self().Data().From("https://cdn.andrewmclachlan.com");
-        options.AddStyleSrc().Self().UnsafeInline();
-        options.AddScriptSrc().Self();
-        options.AddFontSrc().Self().From("https://cdn.andrewmclachlan.com");
-    })
-    .AddPermissionsPolicyWithDefaultSecureDirectives();
+        policies.AddContentSecurityPolicy(options =>
+        {
+            options.AddDefaultSrc().Self();
+            options.AddConnectSrc().Self();
+            options.AddImgSrc().Self().Data().From("https://cdn.andrewmclachlan.com");
+            options.AddStyleSrc().Self().UnsafeInline();
+            options.AddScriptSrc().Self();
+            options.AddFontSrc().Self().From("https://cdn.andrewmclachlan.com");
+        });
+        policies.AddPermissionsPolicyWithDefaultSecureDirectives();
+    });
+
+    services.AddCanonicalUrls(opts =>
+    {
+        opts.ExemptPathPrefixes = ["/umbraco", "/install", "/media", "/fonts"];
+    });
 
     umbracoBuilder.AddAzureBlobMediaFileSystem();
 
@@ -85,10 +93,7 @@ try
         app.UseHsts();
     }
 
-    app.UseCanonicalUrls(opts =>
-    {
-        opts.ExemptPathPrefixes = ["/umbraco", "/install", "/media", "/fonts"];
-    });
+    app.UseCanonicalUrls();
 
     app.MapGet("robots.txt", () =>
     @$"User-agent: *


### PR DESCRIPTION
Migrates the Asm shared libraries from **3.8.162** to **4.0.31**, applying the v4 breaking changes that affect this project.

## Changes

**`Directory.Packages.props`** — bump the six referenced packages (`Asm`, `Asm.AspNetCore`, `Asm.AspNetCore.Mvc`, `Asm.Net`, `Asm.Umbraco`, `Asm.Umbraco.Authentication`) to `4.0.31`.

**`src/AmCom.Web/Program.cs`** (Batch 7 — options-pattern conformance):
- `AddStandardSecurityHeaders` now returns `IServiceCollection`, so the CSP and permissions-policy setup moves into its `configure` callback rather than being chained off the return value.
- Canonical-URL options move to `services.AddCanonicalUrls(...)` at registration; `app.UseCanonicalUrls()` is now parameterless (the inline-configure overload is `[Obsolete]` in v4).

## Not applicable
The CQRS, repositories/specifications, modules, ProblemDetails, domain-events, Nybble, and Win32 v4 batches have zero usages in this repo.

## Operational note (already done)
Batch 9 renamed the EntraID back-office callback path from `/signin-oidc` to `/signin-entraid` (and the scheme from `OpenIdConnect` to `EntraId`). `AddEntraIdAuthentication` is source-compatible, but the Azure app-registration redirect URI needed updating — **this has been done**. Existing back-office external logins keyed on the old scheme may need re-linking.

## Verification
- `dotnet build src/AmCom.Web` succeeds with 0 errors and no `[Obsolete]` warnings (the only warnings are the pre-existing `NU1903` SQLite advisory).
- Suggested staging smoke test: confirm security headers (CSP/permissions-policy) still emit on a normal page, a mixed-case/trailing-slash URL still canonical-redirects, and back-office EntraID login works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)