### PR TITLE
Restore primary nav separator

### DIFF
--- a/src/AmCom.Web/Views/Layout.cshtml
+++ b/src/AmCom.Web/Views/Layout.cshtml
@@ -2,7 +2,7 @@
 @inject Microsoft.AspNetCore.Hosting.IWebHostEnvironment hostingEnv
 @{
     var site = Model.Root();
-    var selection = site.Children().Where(x => x.IsVisible());
+    var selection = site.Children().Where(x => x.IsVisible()).ToArray();
     Layout = null;
 }
 <!DOCTYPE html>
@@ -50,7 +50,7 @@
         @foreach(var item in selection)
         {
           string cssclass = "nav-item" + (item.IsAncestorOrSelf(Model) ? " active" : String.Empty);
-          if (item.Equals(selection.Last()))
+          if (item.Key == selection.Last().Key)
           {
             cssclass += " level-last";
           }
@@ -61,10 +61,6 @@
           foreach (var item in selection.SingleOrDefault(s => s.IsAncestorOrSelf(Model))?.Children().Where(x => x.IsVisible()) ?? Array.Empty<IPublishedContent>())
           {
             string cssclass = "nav-item" + (item.IsAncestorOrSelf(Model) ? " active" : String.Empty);
-            if (item.Equals(selection.Last()))
-            {
-              cssclass += " level-last";
-            }
 
             <li class="@cssclass"><a class="nav-link" href="@item.Url()">@item.ValueOr("navigationText", item.Name())</a></li>
           }


### PR DESCRIPTION
## Summary

- Restore the blue divider between the primary and secondary navigation menus.
- Materialize the primary navigation collection and identify its final item by the stable Umbraco content key.
- Remove the unreachable secondary-navigation boundary check.

## Root cause

The view re-enumerated the primary content collection and compared content wrapper objects with `Equals`. After the CMS upgrade, equivalent content can be represented by different wrapper instances, so the final primary item no longer received the `level-last` class that supplies the divider.

## Impact

The visual boundary between primary items such as `tools` and secondary items such as `postie` is restored, while navigation without secondary items remains unchanged.

## Validation

- `dotnet build AmCom.slnx`
- Build completed with 0 warnings and 0 errors.