### PR TITLE
Make the updated date authoritative, and stop guessing at it

### DIFF
--- a/src/AmCom.Web/Data/ArticleBody.cs
+++ b/src/AmCom.Web/Data/ArticleBody.cs
@@ -1,0 +1,62 @@
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Extensions;
+
+namespace Asm.AmCom.Web.Data;
+
+/// <summary>
+/// Identifies an article body by what it says, not by how Umbraco happens to have stored it.
+/// </summary>
+/// <remarks>
+/// The rich text editor stores <c>{"markup":"...","blocks":{...}}</c>. Only <c>markup</c> is editorial; the
+/// blocks envelope is re-emitted by whichever serialiser last wrote the value. Hashing the whole value made
+/// that a trap: moving the articles onto the Article document type rewrote <c>"Layout"</c> as <c>"layout"</c>
+/// and changed nothing else, and a whole-value hash read that one character as the article being revised —
+/// so every article claimed it had been updated on the day of the deploy.
+/// </remarks>
+internal static class ArticleBody
+{
+    public const string PropertyAlias = "pageContent";
+
+    /// <summary>Hashes an article's body, or null when it has none to hash.</summary>
+    public static string? Hash(IContentBase content) =>
+        Hash(content.GetValue<string>(PropertyAlias));
+
+    /// <summary>Hashes a raw stored body value, or null when it is empty.</summary>
+    public static string? Hash(string? value)
+    {
+        var markup = Markup(value);
+
+        return String.IsNullOrWhiteSpace(markup)
+            ? null
+            : Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(markup)));
+    }
+
+    private static string? Markup(string? value)
+    {
+        if (String.IsNullOrWhiteSpace(value)) return null;
+
+        // Values written before the rich text editor gained block support are bare HTML, not JSON.
+        if (!value.AsSpan().TrimStart().StartsWith("{")) return value;
+
+        try
+        {
+            using var document = JsonDocument.Parse(value);
+
+            if (document.RootElement.ValueKind == JsonValueKind.Object &&
+                document.RootElement.TryGetProperty("markup", out var markup) &&
+                markup.ValueKind == JsonValueKind.String)
+            {
+                return markup.GetString();
+            }
+        }
+        catch (JsonException)
+        {
+            // Not the shape we expected — fall back to the whole value rather than lose the change entirely.
+        }
+
+        return value;
+    }
+}

--- a/src/AmCom.Web/Data/ContentDateRow.cs
+++ b/src/AmCom.Web/Data/ContentDateRow.cs
@@ -35,8 +35,19 @@ public class ContentDateRow
     [NullSetting(NullSetting = NullSettings.Null)]
     public DateTime? FirstPublished { get; set; }
 
-    /// <summary>When the body last actually changed, ignoring metadata-only saves.</summary>
+    /// <summary>
+    /// When the body last actually changed. Authoritative: set it by hand and nothing will overwrite it
+    /// until the article is genuinely edited again.
+    /// </summary>
     [Column("lastContentChange")]
     [NullSetting(NullSetting = NullSettings.Null)]
     public DateTime? LastContentChange { get; set; }
+
+    /// <summary>
+    /// Hash of the body as last seen, so a save can be told from a re-serialisation of the same text.
+    /// </summary>
+    [Column("contentHash")]
+    [NullSetting(NullSetting = NullSettings.Null)]
+    [Length(64)]
+    public string? ContentHash { get; set; }
 }

--- a/src/AmCom.Web/Data/ContentDateService.cs
+++ b/src/AmCom.Web/Data/ContentDateService.cs
@@ -12,8 +12,11 @@ public interface IContentDateService
     /// <summary>Records the first publication, leaving an existing value alone.</summary>
     void SetFirstPublished(int nodeId, DateTime when);
 
-    /// <summary>Records a body change, overwriting any previous value.</summary>
-    void SetLastContentChange(int nodeId, DateTime? when);
+    /// <summary>
+    /// Records the body as currently seen, advancing <see cref="ContentDateRow.LastContentChange"/> only if it
+    /// differs from the body seen last time.
+    /// </summary>
+    void RecordBody(int nodeId, string hash, DateTime when);
 }
 
 public class ContentDateService : IContentDateService
@@ -39,16 +42,32 @@ public class ContentDateService : IContentDateService
         Upsert(nodeId, row =>
         {
             // First publication only — a later publish must not restate when something came out.
-            if (row.FirstPublished is null)
-            {
-                row.FirstPublished = when;
-            }
+            if (row.FirstPublished is not null) return false;
+
+            row.FirstPublished = when;
+            return true;
         });
 
-    public void SetLastContentChange(int nodeId, DateTime? when) =>
-        Upsert(nodeId, row => row.LastContentChange = when);
+    public void RecordBody(int nodeId, string hash, DateTime when) =>
+        Upsert(nodeId, row =>
+        {
+            // Same text as last time: a re-publish, a metadata edit, or the serialiser rewriting its own
+            // envelope. None of those are a revision.
+            if (row.ContentHash == hash) return false;
 
-    private void Upsert(int nodeId, Action<ContentDateRow> apply)
+            // Nothing to compare against yet, so there is no evidence of a change — record what the body is
+            // now and leave the date alone. This is what stops a first sighting (a newly created article, or
+            // the backfill running against an existing one) from being reported as an update.
+            if (row.ContentHash is not null)
+            {
+                row.LastContentChange = when;
+            }
+
+            row.ContentHash = hash;
+            return true;
+        });
+
+    private void Upsert(int nodeId, Func<ContentDateRow, bool> apply)
     {
         using var scope = _scopeProvider.CreateScope();
 
@@ -56,7 +75,11 @@ public class ContentDateService : IContentDateService
         var isNew = row is null;
         row ??= new ContentDateRow { NodeId = nodeId };
 
-        apply(row);
+        if (!apply(row) && !isNew)
+        {
+            scope.Complete();
+            return;
+        }
 
         if (isNew)
         {

--- a/src/AmCom.Web/Data/ContentDatesMigrationPlan.cs
+++ b/src/AmCom.Web/Data/ContentDatesMigrationPlan.cs
@@ -5,7 +5,9 @@ namespace Asm.AmCom.Web.Data;
 public class ContentDatesMigrationPlan : MigrationPlan
 {
     public ContentDatesMigrationPlan() : base("AmCom.ContentDates") =>
-        From(String.Empty).To<AddContentDatesTable>("content-dates-1");
+        From(String.Empty)
+            .To<AddContentDatesTable>("content-dates-1")
+            .To<AddContentHashColumn>("content-dates-2");
 }
 
 public class AddContentDatesTable : AsyncMigrationBase
@@ -19,6 +21,25 @@ public class AddContentDatesTable : AsyncMigrationBase
         if (!TableExists(ContentDateRow.TableName))
         {
             Create.Table<ContentDateRow>().Do();
+        }
+
+        return Task.CompletedTask;
+    }
+}
+
+public class AddContentHashColumn : AsyncMigrationBase
+{
+    public AddContentHashColumn(IMigrationContext context) : base(context)
+    {
+    }
+
+    protected override Task MigrateAsync()
+    {
+        // Table<ContentDateRow>() above creates the column on a fresh database, so this is only for the ones
+        // that already have the table.
+        if (!ColumnExists(ContentDateRow.TableName, "contentHash"))
+        {
+            Create.Column("contentHash").OnTable(ContentDateRow.TableName).AsString(64).Nullable().Do();
         }
 
         return Task.CompletedTask;

--- a/src/AmCom.Web/Data/ContentDatesSeed.cs
+++ b/src/AmCom.Web/Data/ContentDatesSeed.cs
@@ -7,25 +7,30 @@ using Umbraco.Extensions;
 namespace Asm.AmCom.Web.Data;
 
 /// <summary>
-/// Backfills <see cref="ContentDateRow"/> from Umbraco's own records, once per environment.
+/// Fills in what is missing from <see cref="ContentDateRow"/>, and only what is missing.
 /// </summary>
 /// <remarks>
-/// Both dates are recovered from real data rather than guessed. <c>firstPublished</c> comes from the earliest
-/// Publish entry in the audit log, which on this site reaches back to 2022. <c>lastContentChange</c> is
-/// reconstructed by hashing <c>pageContent</c> across retained versions and taking the last version where it
-/// differs from the one before it.
-///
-/// That second reconstruction is deliberately conservative: a change is only counted between two *retained*
-/// versions. The earliest retained version is skipped, because "oldest snapshot still held" is
-/// indistinguishable from "created then", and counting it would manufacture an update date out of version
-/// cleanup. Articles with nothing detectable are left null and simply show no updated date.
+/// <para>
+/// Runs on every startup and is deliberately incapable of changing a value that is already there. There is no
+/// state key to bump: nothing here is a one-shot that has to be replayed, so nothing here can undo a date that
+/// was set by hand.
+/// </para>
+/// <para>
+/// <c>firstPublished</c> is read from the earliest Publish entry in the audit log, which on this site reaches
+/// back to 2022 and is a record of something that actually happened.
+/// </para>
+/// <para>
+/// <c>lastContentChange</c> is not reconstructed. It was, by hashing <c>pageContent</c> across retained
+/// versions and taking the last version whose hash differed — but a stored version is a snapshot of a
+/// serialisation, not of an edit, so re-saving an article with no changes produces a new hash whenever the
+/// serialiser's output has drifted. That is not a bug that can be patched out with a better query: version
+/// history genuinely does not record whether the text changed, only that it was written. So this seeds the
+/// hash of the body as it stands now, and from that point on the date moves when the text really does.
+/// Articles from before then simply have no updated date until one is set, and a date set by hand stays set.
+/// </para>
 /// </remarks>
 public class ContentDatesSeed : INotificationHandler<UmbracoApplicationStartedNotification>
 {
-    // Versioned: bumping it re-seeds on the next deploy. The first version mistook the document type
-    // migration's own rewrite for an edit and dated every article to deploy day.
-    private const string StateKey = "AmCom.Migration.ContentDatesSeed.v2";
-
     private const string ArticleNodesSql = """
         SELECT c.nodeId
         FROM umbracoContent c
@@ -33,7 +38,7 @@ public class ContentDatesSeed : INotificationHandler<UmbracoApplicationStartedNo
         WHERE ct.alias = 'article'
         """;
 
-    private const string FirstPublishedSql = $"""
+    private const string FirstPublishedSql = """
         SELECT l.NodeId AS NodeId, MIN(l.Datestamp) AS FirstPublished
         FROM umbracoLog l
         JOIN umbracoContent c ON c.nodeId = l.NodeId
@@ -42,91 +47,64 @@ public class ContentDatesSeed : INotificationHandler<UmbracoApplicationStartedNo
         GROUP BY l.NodeId
         """;
 
-    // Leading semicolon: NPoco prepends to the command, and a CTE must start a statement.
-    private const string LastContentChangeSql = $"""
-        ;WITH raw AS (
-            SELECT cv.nodeId, cv.id AS versionId, cv.versionDate,
-                   HASHBYTES('MD5', CAST(pd.textValue AS nvarchar(max))) AS h,
-                   -- A version can carry two pageContent rows once the document type migration has run: the
-                   -- one bound to contentPage's property type and the one bound to article's. Keep only the
-                   -- row for the type the node actually uses now, otherwise the pair reads as a body change
-                   -- at the migration's timestamp and every article looks like it was edited on deploy day.
-                   ROW_NUMBER() OVER (
-                       PARTITION BY cv.id
-                       ORDER BY CASE WHEN pt.contentTypeId = c.contentTypeId THEN 0 ELSE 1 END, pd.id) AS rn
-            FROM umbracoContentVersion cv
-            JOIN umbracoContent c ON c.nodeId = cv.nodeId
-            JOIN cmsContentType ct ON ct.nodeId = c.contentTypeId
-            -- Matched by alias alone, not scoped to the article type: versions predating the document type
-            -- migration still reference contentPage's pageContent property type, and excluding them would
-            -- hide every change made before the move.
-            JOIN cmsPropertyType pt ON pt.Alias = 'pageContent'
-            JOIN umbracoPropertyData pd ON pd.versionId = cv.id AND pd.propertyTypeId = pt.id
-            WHERE ct.alias = 'article' AND pd.textValue IS NOT NULL
-        ), v AS (
-            SELECT nodeId, versionId, versionDate, h FROM raw WHERE rn = 1
-        ), d AS (
-            SELECT nodeId, versionDate, h,
-                   -- versionId breaks ties: several versions can share a timestamp to the second.
-                   LAG(h) OVER (PARTITION BY nodeId ORDER BY versionDate, versionId) AS prevH
-            FROM v
-        )
-        SELECT nodeId AS NodeId, MAX(versionDate) AS LastContentChange
-        FROM d
-        WHERE prevH IS NOT NULL AND h <> prevH
-        GROUP BY nodeId
-        """;
-
     private readonly IScopeProvider _scopeProvider;
-    private readonly IKeyValueService _keyValueService;
+    private readonly IContentService _contentService;
     private readonly IContentDateService _contentDateService;
     private readonly ILogger<ContentDatesSeed> _logger;
 
-    public ContentDatesSeed(IScopeProvider scopeProvider, IKeyValueService keyValueService, IContentDateService contentDateService, ILogger<ContentDatesSeed> logger)
+    public ContentDatesSeed(IScopeProvider scopeProvider, IContentService contentService, IContentDateService contentDateService, ILogger<ContentDatesSeed> logger)
     {
         _scopeProvider = scopeProvider;
-        _keyValueService = keyValueService;
+        _contentService = contentService;
         _contentDateService = contentDateService;
         _logger = logger;
     }
 
     public void Handle(UmbracoApplicationStartedNotification notification)
     {
-        if (_keyValueService.GetValue(StateKey) is not null) return;
-
         List<int> articles;
-        List<SeedRow> published;
-        List<SeedRow> changed;
+        List<FirstPublishedRow> published;
+
         using (var scope = _scopeProvider.CreateScope(autoComplete: true))
         {
             articles = scope.Database.Fetch<int>(ArticleNodesSql);
-            published = scope.Database.Fetch<SeedRow>(FirstPublishedSql);
-            changed = scope.Database.Fetch<SeedRow>(LastContentChangeSql);
+            published = scope.Database.Fetch<FirstPublishedRow>(FirstPublishedSql);
         }
 
         foreach (var row in published.Where(r => r.FirstPublished is not null))
         {
+            // Ignored when a value is already stored.
             _contentDateService.SetFirstPublished(row.NodeId, row.FirstPublished!.Value);
         }
 
-        // Written for every article, not just the ones with a detectable change, so that a re-seed clears
-        // values an earlier version got wrong rather than leaving them behind.
-        var byNode = changed.Where(r => r.LastContentChange is not null)
-                            .ToDictionary(r => r.NodeId, r => r.LastContentChange);
+        var recorded = 0;
 
         foreach (var nodeId in articles)
         {
-            _contentDateService.SetLastContentChange(nodeId, byNode.GetValueOrDefault(nodeId));
+            var content = _contentService.GetById(nodeId);
+            if (content is null) continue;
+
+            // Hashed through the same path the save handler uses, so the first real edit after this compares
+            // like with like rather than tripping over two different ways of reading the same body.
+            var hash = ArticleBody.Hash(content);
+
+            if (hash is null)
+            {
+                _logger.LogWarning("No body found on article {Id} ({Name}); its changes cannot be tracked.", nodeId, content.Name);
+                continue;
+            }
+
+            // Only writes where no hash is stored yet; never moves a date on its own.
+            _contentDateService.RecordBody(nodeId, hash, DateTime.UtcNow);
+            recorded++;
         }
 
-        _keyValueService.SetValue(StateKey, $"{published.Count} published, {byNode.Count} of {articles.Count} changed");
-        _logger.LogInformation("Content dates seeded: {Published} first-published, {Changed} of {Total} with a detectable body change.", published.Count, byNode.Count, articles.Count);
+        _logger.LogInformation("Content dates reconciled: {Published} first-published date(s) available, {Recorded} of {Total} article bodies hashed.", published.Count, recorded, articles.Count);
     }
 
-    private sealed class SeedRow
+    private sealed class FirstPublishedRow
     {
         public int NodeId { get; set; }
         public DateTime? FirstPublished { get; set; }
-        public DateTime? LastContentChange { get; set; }
     }
 }

--- a/src/AmCom.Web/Notifications/LastContentChangeHandler.cs
+++ b/src/AmCom.Web/Notifications/LastContentChangeHandler.cs
@@ -5,37 +5,47 @@ using Umbraco.Cms.Core.Notifications;
 namespace Asm.AmCom.Web.Notifications;
 
 /// <summary>
-/// Records when an article's body actually changes, ignoring metadata-only saves.
+/// Records when an article's body actually changes, ignoring saves that leave the text alone.
 /// </summary>
 /// <remarks>
 /// A node's <c>UpdateDate</c> moves on every save — a description tweak, a re-publish, a bulk migration
-/// touching every node — so it overstates when an article was really revised. Umbraco's dirty tracking knows
-/// which properties changed, but only inside the save pipeline, so the answer is captured here.
+/// touching every node — so it overstates when an article was really revised. Umbraco's dirty tracking is
+/// closer, but it reports the property as changed whenever the value was rewritten, including when the new
+/// value says exactly what the old one said. Comparing the body against the one seen last time is the only
+/// test that survives that, so that is what this does.
 /// </remarks>
 public class LastContentChangeHandler : INotificationHandler<ContentSavedNotification>
 {
-    private const string BodyProperty = "pageContent";
     private const string ArticleAlias = "article";
 
     private readonly IContentDateService _contentDateService;
+    private readonly ILogger<LastContentChangeHandler> _logger;
 
-    public LastContentChangeHandler(IContentDateService contentDateService) =>
+    public LastContentChangeHandler(IContentDateService contentDateService, ILogger<LastContentChangeHandler> logger)
+    {
         _contentDateService = contentDateService;
+        _logger = logger;
+    }
 
     public void Handle(ContentSavedNotification notification)
     {
-        // Migrations rewrite the body to move it between property types. That is not an editorial revision,
-        // and recording it would produce exactly the bogus "updated today" this handler exists to avoid.
         if (LastContentChangeSuppression.IsActive) return;
 
         foreach (var content in notification.SavedEntities)
         {
             if (content.ContentType.Alias != ArticleAlias) continue;
 
-            // WasPropertyDirty (not IsPropertyDirty) because this runs after the save is persisted.
-            if (!content.WasPropertyDirty(BodyProperty)) continue;
+            var hash = ArticleBody.Hash(content);
 
-            _contentDateService.SetLastContentChange(content.Id, DateTime.UtcNow);
+            if (hash is null)
+            {
+                // An article with an empty body. Recording nothing keeps whatever date is already stored,
+                // which beats treating "I can't see a body" as "the body changed".
+                _logger.LogWarning("No body found on article {Id} ({Name}); leaving its dates untouched.", content.Id, content.Name);
+                continue;
+            }
+
+            _contentDateService.RecordBody(content.Id, hash, DateTime.UtcNow);
         }
     }
 }
@@ -45,6 +55,10 @@ public class LastContentChangeHandler : INotificationHandler<ContentSavedNotific
 /// editorially — currently document type migrations, which must rewrite the body to rebind it to the new
 /// type's property types.
 /// </summary>
+/// <remarks>
+/// Belt and braces since the handler compares the text itself: a mechanical rewrite produces the same body and
+/// so moves nothing anyway. Kept because a future migration might legitimately reshape the markup.
+/// </remarks>
 internal static class LastContentChangeSuppression
 {
     private static readonly AsyncLocal<bool> Active = new();


### PR DESCRIPTION
Fixes the updated dates still reading as the deploy date, and — more importantly — stops anything overwriting a date set by hand.

## What was actually wrong

I finally have the evidence rather than a model. The two article versions written on 26 July are both 12,320 characters. They differ by **one character**, at position 12309:

```
..."expose":[],"Layout":{}}}     ← version 258 (10:47, the doc type migration)
..."expose":[],"layout":{}}}     ← version 288 (10:53)
```

That is the rich text editor's `blocks` envelope being re-serialised. The prose is byte-identical. The seed hashed the **whole stored value**, so it read that capital `L` as the article being revised — and dated every affected article to the day of the deploy. SECO escaped only because its value happened not to get rewritten, which is why one of the three looked right and made the earlier fix seem to work.

My previous attempt (#343) addressed a real but different issue — two `pageContent` rows per version — and left this untouched.

## Why this is the last query-shaped fix

A stored version is a snapshot of a *serialisation*, not of an *edit*. Version history does not record whether the text changed, only that it was written. No smarter query recovers what was never written down, so this stops trying:

- **`ArticleBody`** hashes the rich text `markup` alone, never the envelope around it. One definition of what an article body says, used by both the save handler and the backfill so the two cannot disagree.
- **The save handler** compares that hash against the body seen last time (new `contentHash` column) instead of trusting dirty tracking, which reports a property as changed whenever it was rewritten — saying the same thing or not.
- **The backfill no longer reconstructs `lastContentChange` at all.** It is now authoritative: set it by hand and nothing overwrites it until the article is genuinely edited again.
- **The seed's state key is gone.** It fills only what is missing and runs every startup, so there is nothing left to bump — and bumping it is exactly what destroyed hand-set dates on the last two deploys.

`firstPublished` still comes from the audit log, and still only fills a missing value.

## Verified locally, against real article data

| Action | `lastContentChange` | `contentHash` |
|---|---|---|
| Startup, dates set by hand | unchanged | filled in |
| Save **and publish**, body untouched | unchanged | unchanged |
| Append a paragraph | advances to today | changes |
| Restore that paragraph | advances | returns to its original value |
| Second startup | unchanged | unchanged |

The hash returning to its original value after the edit was undone confirms the test left the article byte-identical.

## After deploying

This deploy will not correct the wrong dates — by design, since not overwriting stored values is the point. Set them once and they will stay set:

```sql
UPDATE amcomContentDates SET lastContentChange = '2026-05-11 10:26:17'
  WHERE nodeId = (SELECT id FROM umbracoNode WHERE text = 'Azure');

UPDATE amcomContentDates SET lastContentChange = '2026-05-09 08:55:20'
  WHERE nodeId = (SELECT id FROM umbracoNode WHERE text = 'SECO');

-- Or clear one to show no updated date at all:
UPDATE amcomContentDates SET lastContentChange = NULL
  WHERE nodeId = (SELECT id FROM umbracoNode WHERE text = 'Postie');
```

Those timestamps are the local values and are a guess at your intent — use whatever dates you consider right. Times are UTC.

## Known, not fixed here

Deleting an article leaves its row behind; the table has no foreign key to `umbracoNode`. Cosmetic — orphan rows are never read, since every lookup is by the id of a node that exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)