### PR TITLE
Make the canonical URL absolute

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,12 +4,12 @@
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="Asm" Version="5.0.13" />
-    <PackageVersion Include="Asm.AspNetCore" Version="5.0.13" />
-    <PackageVersion Include="Asm.AspNetCore.Mvc" Version="5.0.13" />
-    <PackageVersion Include="Asm.Net" Version="5.0.13" />
-    <PackageVersion Include="Asm.Umbraco" Version="5.0.13" />
-    <PackageVersion Include="Asm.Umbraco.Authentication" Version="5.0.13" />
+    <PackageVersion Include="Asm" Version="5.0.22" />
+    <PackageVersion Include="Asm.AspNetCore" Version="5.0.22" />
+    <PackageVersion Include="Asm.AspNetCore.Mvc" Version="5.0.22" />
+    <PackageVersion Include="Asm.Net" Version="5.0.22" />
+    <PackageVersion Include="Asm.Umbraco" Version="5.0.22" />
+    <PackageVersion Include="Asm.Umbraco.Authentication" Version="5.0.22" />
     <PackageVersion Include="Azure.Extensions.AspNetCore.DataProtection.Blobs" Version="1.5.3" />
     <PackageVersion Include="Azure.Extensions.AspNetCore.DataProtection.Keys" Version="1.6.3" />
     <PackageVersion Include="Azure.Identity" Version="1.21.0" />

--- a/src/AmCom.Web/Views/Article.cshtml
+++ b/src/AmCom.Web/Views/Article.cshtml
@@ -5,7 +5,7 @@
     Layout = "FullPageLayout.cshtml";
     ViewBag.Title = $"{Model.Value("title")} - Andrew McLachlan";
     ViewBag.Description = Model.Value("description");
-    ViewBag.Canonical = Model.Url();
+    ViewBag.Canonical = Model.Url(mode: UrlMode.Absolute);
     ViewBag.PageType = "article";
 
     var dates = ContentDates.Get(Model.Id);

--- a/src/AmCom.Web/Views/Home.cshtml
+++ b/src/AmCom.Web/Views/Home.cshtml
@@ -4,7 +4,7 @@
     Layout = "Layout.cshtml";
     ViewBag.Title = Model.Value("title");
     ViewBag.Description = Model.Value("description");
-    ViewBag.Canonical = Model.Url();
+    ViewBag.Canonical = Model.Url(mode: UrlMode.Absolute);
     ViewBag.PageType = "website";
 }
 

--- a/src/AmCom.Web/Views/LandingPage.cshtml
+++ b/src/AmCom.Web/Views/LandingPage.cshtml
@@ -4,7 +4,7 @@
     Layout = "FullPageLayout.cshtml";
     ViewBag.Title = $"{Model.Title} - Andrew McLachlan";
     ViewBag.Description = Model.Description;
-    ViewBag.Canonical = Model.Url();
+    ViewBag.Canonical = Model.Url(mode: UrlMode.Absolute);
     ViewBag.PageType = "website";
     var cards = Model.Cards;
 }

--- a/src/AmCom.Web/Views/Page.cshtml
+++ b/src/AmCom.Web/Views/Page.cshtml
@@ -4,7 +4,7 @@
     Layout = "FullPageLayout.cshtml";
     ViewBag.Title = $"{Model.Value("title")} - Andrew McLachlan";
     ViewBag.Description = Model.Value("description");
-    ViewBag.Canonical = Model.Url();
+    ViewBag.Canonical = Model.Url(mode: UrlMode.Absolute);
     ViewBag.PageType = Model.Value("pageType") ?? "website";
     var pageLinks = Model.PageLinks;// Model.Value<IEnumerable<Umbraco.Cms.Web.Common.PublishedModels.PageLink>>("PageLinks") ?? [];
 }

--- a/src/AmCom.Web/Views/Tool.cshtml
+++ b/src/AmCom.Web/Views/Tool.cshtml
@@ -4,7 +4,7 @@
     Layout = "FullPageLayout.cshtml";
     ViewBag.Title = $"{Model.Value("title")} - Andrew McLachlan";
     ViewBag.Description = Model.Value("description");
-    ViewBag.Canonical = Model.Url();
+    ViewBag.Canonical = Model.Url(mode: UrlMode.Absolute);
     ViewBag.PageType = "website";
     string toolName = Model.Value<string>("toolName")!;
 }

--- a/src/AmCom.Web/Views/ToolIP.cshtml
+++ b/src/AmCom.Web/Views/ToolIP.cshtml
@@ -4,7 +4,7 @@
     Layout = "FullPageLayout.cshtml";
     ViewBag.Title = $"{Model.Value("title")} - Andrew McLachlan";
     ViewBag.Description = Model.Value("description");
-    ViewBag.Canonical = Model.Url();
+    ViewBag.Canonical = Model.Url(mode: UrlMode.Absolute);
     ViewBag.PageType = "website";
 
     string ip = "";


### PR DESCRIPTION
`og:url` and the schema.org `"url"` were emitting a site-relative path — the live article was serving `<meta property="og:url" content="/articles/postie" />`, which neither Open Graph nor schema.org allows.

Both read `ViewBag.Canonical`, which held `Model.Url()`. That had to stay relative because `CanonicalTagHelper` built the absolute URL itself and would otherwise have doubled the host.

## Change

- Bump Asm packages 5.0.13 → 5.0.22, which carries the tag helper fix from [ASM #447](https://github.com/AndrewMcLachlan/ASM/pull/447) — an absolute URL now passes through untouched.
- `ViewBag.Canonical = Model.Url(mode: UrlMode.Absolute)` in the six views that set it.

No change was needed at the point of use: `og:url` and the JSON-LD already read `ViewBag.Canonical`, so making the value genuinely canonical fixes every consumer at once — including the `"url"` in the `Article`, `LandingPage`, `Page` and `Tool` structured data, which had the same bug.

## Verification

These views compile at runtime, so neither `dotnet build` nor `dotnet publish` validates them — this was checked by running the site locally:

| | canonical | og:url | JSON-LD `url` |
|---|---|---|---|
| `/` | `https://host` | `https://host/` | — |
| `/articles/postie` | `https://host/articles/postie` | `https://host/articles/postie` | `https://host/articles/postie` |
| `/projects/postie` | `https://host/projects/postie` | `https://host/projects/postie` | — |

The canonical link has a single host, confirming the upgraded tag helper passes an absolute URL through rather than prefixing it again.

## Note

The root page emits `https://host` for canonical but `https://host/` for `og:url` — the tag helper trims a trailing slash and `og:url` doesn't. Both are valid and equivalent for the root, so I've left it alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)